### PR TITLE
added a single do-nothing test as an example

### DIFF
--- a/src/test/java/frc/robot/TestThatTestsRun.java
+++ b/src/test/java/frc/robot/TestThatTestsRun.java
@@ -1,0 +1,18 @@
+
+package frc.robot;
+
+import org.junit.jupiter.api.Test;
+
+
+/**
+ * 
+ *
+ * @author dcowden
+ */
+public class TestThatTestsRun {
+    
+    @Test
+    public void testThatThisIsExecuted(){
+    }
+    
+}

--- a/src/test/java/frc/robot/TestThatTestsRun.java
+++ b/src/test/java/frc/robot/TestThatTestsRun.java
@@ -15,4 +15,10 @@ public class TestThatTestsRun {
     public void testThatThisIsExecuted(){
     }
     
+    @Test
+    public void testThatThisBreaks(){
+        throw new RuntimeException("Error");
+    }
+    
+    
 }

--- a/src/test/java/frc/robot/TestThatTestsRun.java
+++ b/src/test/java/frc/robot/TestThatTestsRun.java
@@ -17,7 +17,7 @@ public class TestThatTestsRun {
     
     @Test
     public void testThatThisBreaks(){
-        throw new RuntimeException("Error");
+        //throw new RuntimeException("Error");
     }
     
     


### PR DESCRIPTION
This adds a single test, which does nothing but demonstrates a working test, and lets me set up actions to reject builds with failing tests.