### PR TITLE
Add diagnostics and setpoint to HoldYawFilter

### DIFF
--- a/src/main/java/frc/robot/commands/FilteredDriveCommand.java
+++ b/src/main/java/frc/robot/commands/FilteredDriveCommand.java
@@ -41,6 +41,12 @@ public class FilteredDriveCommand extends SimpleDriveCommand {
         yawHoldFilter.setEnabled(false);
     }
 
+    @Override 
+    public void initialize() {
+        yawHoldFilter.updateSetpoint(operatorInput.get().getRawYawAngleDegrees());
+        yawHoldFilter.reset();
+    }
+
     @Override
     public void execute() {
     	DriveInput di = operatorInput.get();

--- a/src/main/java/frc/robot/filters/HoldYawFilter.java
+++ b/src/main/java/frc/robot/filters/HoldYawFilter.java
@@ -1,5 +1,6 @@
 package frc.robot.filters;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.RobotConstants;
 import frc.robot.controllers.RobotYawPIDController;
 
@@ -31,11 +32,16 @@ public class HoldYawFilter extends DriveInputFilter {
         DriveInput newDi = new DriveInput(original);        		
 
         newDi.setRotation(pid.calculate(original.getRawYawAngleDegrees(), yawSetPoint));
+        DriverStation.reportWarning("HoldYaw: " + original.getRawYawAngleDegrees() + " , " + yawSetPoint + " , " + newDi.getRotation() , false);
         return newDi;
     }
 
     public void updateSetpoint( double yaw ) {
         yawSetPoint = yaw;
+    }
+
+    public void reset() {
+        pid.reset();
     }
 
 }


### PR DESCRIPTION
This keeps the HoldYawFilter disabled; but adds some diagnostics and initialization to the filter to see what's happening.