### PR TITLE
Ma 3 stage balance

### DIFF
--- a/src/main/java/frc/robot/RobotConstants.java
+++ b/src/main/java/frc/robot/RobotConstants.java
@@ -156,15 +156,16 @@ public final class RobotConstants {
         public static final double ROTATION_DAMPING_FACTOR = 0.5;
         public static final double SPEED_LIMIT_WITH_ARM_OUT = 0.7;
         public static final double YAW_NUDGE_DEGREES = 3.5;
+        public static final double WHEELBASE_INCHES = 24.5;
     }
     public interface BALANCE_PARAMETERS {
-        public static final double CHARGESTATION_APPROACH_SPEED = 0.35;
-        public static final double TIP_PITCH_THRESHOLD = 10.0;
-        public static final double DOCK_DISTANCE = 0.5*1.22;  // charge stattion platform depth = 4ft (1.22m)
-        public static final double DOCK_INITIAL_SPEED = 0.35;
-        public static final double DOCK_FINAL_SPEED = 0.15;
-        public static final double BALANCE_SPEED = 0.10;
-        public static final double BALANCE_PITCH_THRESHOLD = 12.0;
+        public static final double CHARGESTATION_APPROACH_SPEED = 0.33;
+        public static final double TIP_PITCH_THRESHOLD = 7.0; // probably should be closer to 15.0
+        public static final double DOCK_DISTANCE = 0.5*1.22 + 0.25*DRIVE.WHEELBASE_INCHES/39.37;  // charge station platform depth = 4ft (1.22m)
+        public static final double DOCK_INITIAL_SPEED = 0.33;
+        public static final double DOCK_FINAL_SPEED = 0.25;
+        public static final double BALANCE_SPEED = 0.20;
+        public static final double BALANCE_PITCH_THRESHOLD = 5.0;  // probably closer to 12.0
         public static final int    BALANCE_STABLE_COUNT = 100;
         public static final double DEPLOY_BRAKE_AUTO_TIME_REMAINING = 0.25;
     }

--- a/src/main/java/frc/robot/RobotConstants.java
+++ b/src/main/java/frc/robot/RobotConstants.java
@@ -155,8 +155,18 @@ public final class RobotConstants {
         public static final double PRECISION_DRIVE_FACTOR = 0.4;
         public static final double ROTATION_DAMPING_FACTOR = 0.5;
         public static final double SPEED_LIMIT_WITH_ARM_OUT = 0.7;
-        public static final double BALANCE_APPROACH_SPEED = 0.3;
         public static final double YAW_NUDGE_DEGREES = 3.5;
+    }
+    public interface BALANCE_PARAMETERS {
+        public static final double CHARGESTATION_APPROACH_SPEED = 0.35;
+        public static final double TIP_PITCH_THRESHOLD = 10.0;
+        public static final double DOCK_DISTANCE = 0.5*1.22;  // charge stattion platform depth = 4ft (1.22m)
+        public static final double DOCK_INITIAL_SPEED = 0.35;
+        public static final double DOCK_FINAL_SPEED = 0.15;
+        public static final double BALANCE_SPEED = 0.10;
+        public static final double BALANCE_PITCH_THRESHOLD = 12.0;
+        public static final int    BALANCE_STABLE_COUNT = 100;
+        public static final double DEPLOY_BRAKE_AUTO_TIME_REMAINING = 0.25;
     }
     public interface DRIVER_STICK {
         public static final int TURN_TOGGLE = 1;

--- a/src/main/java/frc/robot/commands/DriveCSForwardBalanceCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCSForwardBalanceCommand.java
@@ -90,10 +90,9 @@ public class DriveCSForwardBalanceCommand extends EntechCommandBase {
         brake.setBrakeState(BrakeState.kDeploy);
         pitch_stable_count += 1;
     } else {
-        pitch_stable_count = 0;
-        DriveInput di=new DriveInput(speed,0.0,0.0, 0.0);
         brake.setBrakeState(BrakeState.kRetract);
-        di.setForward(Math.copySign(this.speed, pitch_angle));
+        pitch_stable_count = 0;
+        DriveInput di=new DriveInput(Math.copySign(this.speed, pitch_angle),0.0,0.0, 0.0);
         drive.drive(di);
     }
   }
@@ -113,7 +112,11 @@ public class DriveCSForwardBalanceCommand extends EntechCommandBase {
       DriverStation.reportWarning("AUTONOMOUS ENDING: DEPLOY BRAKE",false);
       return true;
     }
-    return pitch_stable_count > RobotConstants.BALANCE_PARAMETERS.BALANCE_STABLE_COUNT;
+    if (pitch_stable_count > RobotConstants.BALANCE_PARAMETERS.BALANCE_STABLE_COUNT) {
+        DriverStation.reportWarning("END:" + this,false);
+        return true;
+    }
+    return false;
   }
 
   // Returns true if this command should run when robot is disabled.

--- a/src/main/java/frc/robot/commands/DriveCSForwardBalanceCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCSForwardBalanceCommand.java
@@ -1,0 +1,124 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.Timer;
+import frc.robot.RobotConstants;
+import frc.robot.filters.DriveInput;
+import frc.robot.subsystems.BrakeSubsystem;
+import frc.robot.subsystems.BrakeSubsystem.BrakeState;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.NavXSubSystem;
+import frc.robot.subsystems.DriveSubsystem.DriveMode;
+
+public class DriveCSForwardBalanceCommand extends EntechCommandBase {
+  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  private final DriveSubsystem drive;
+  private final NavXSubSystem navx;
+  BrakeSubsystem brake;
+  private boolean pitch_seen;
+  private int pitch_stable_count;
+  private double speed = 0.0;
+  private double original_speed = 0.0;
+  private static final int    ROBOT_STABLE_COUNT = 500;
+  private static final double PITCH_THRESHOLD = 14.0;
+  private static final double SPEED_AFTER_PITCH = 0.13;
+  private static final double PITCH_SLOW_THRESHOLD = 18.0;
+  private static final double PITCH_FLAT_THRESHOLD = 12.0;
+  private static final double BACK_NUDGE_TIME = 0.0;   // Set to zero (or negative) to turn off the back nudge
+  private static final double BACK_NUDGE_SPEED = 0.15;
+  private static final double CHARGESTATION_DEPTH = 1.22;
+  private double start_slowdown;
+  private boolean useBrakes = false;
+  private Timer backNudgeTimer;
+
+  /**
+   * Creates a new DriveForwardToBalanceCommand.
+   *
+   * @param dsubsys Drive subsystem used by this command.
+   * @param nsubsys NavX subsystem used for pitch measurement
+   */
+  public DriveCSForwardBalanceCommand(DriveSubsystem dsubsys, NavXSubSystem nsubsys, BrakeSubsystem bsubsys, boolean useBrakes) {
+	  super(dsubsys,nsubsys,bsubsys);
+      this.drive = dsubsys;
+      this.navx = nsubsys;
+      this.brake = bsubsys;
+      speed = RobotConstants.BALANCE_PARAMETERS.BALANCE_SPEED;
+      this.useBrakes = useBrakes;
+      this.backNudgeTimer = new Timer();
+  }
+
+  /**
+   * Creates a new DriveForwardToBalanceCommand.
+   *
+   * @param dsubsys Drive subsystem used by this command.
+   * @param nsubsys NavX subsystem used for pitch measurement
+   * @param speed Drive speed (forward is positive, default)
+   */
+  public DriveCSForwardBalanceCommand(DriveSubsystem dsubsys, NavXSubSystem nsubsys, BrakeSubsystem bsubsys, double speed,boolean useBrakes) {
+    super(dsubsys,nsubsys,bsubsys);
+    this.drive = dsubsys;
+    this.navx = nsubsys;
+    this.brake = bsubsys;
+    this.speed = speed;
+    original_speed = speed;
+    this.useBrakes = useBrakes;
+    this.backNudgeTimer = new Timer();
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    pitch_seen = false;
+    pitch_stable_count = 0;
+    speed = original_speed;
+    drive.setDriveMode(DriveMode.BRAKE);
+    backNudgeTimer.stop();
+    backNudgeTimer.reset();
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+
+    double pitch_angle = navx.getPitch();
+    if (Math.abs(pitch_angle) < RobotConstants.BALANCE_PARAMETERS.BALANCE_PITCH_THRESHOLD) {
+        drive.stop();
+        brake.setBrakeState(BrakeState.kDeploy);
+        pitch_stable_count += 1;
+    } else {
+        pitch_stable_count = 0;
+        DriveInput di=new DriveInput(speed,0.0,0.0, 0.0);
+        brake.setBrakeState(BrakeState.kRetract);
+        di.setForward(Math.copySign(this.speed, pitch_angle));
+        drive.drive(di);
+    }
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) { 
+    brake.setBrakeState(BrakeState.kDeploy);
+    drive.stop();	  
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    if (DriverStation.isAutonomous() && 
+        ( DriverStation.getMatchTime() < RobotConstants.BALANCE_PARAMETERS.DEPLOY_BRAKE_AUTO_TIME_REMAINING)) {
+      DriverStation.reportWarning("AUTONOMOUS ENDING: DEPLOY BRAKE",false);
+      return true;
+    }
+    return pitch_stable_count > RobotConstants.BALANCE_PARAMETERS.BALANCE_STABLE_COUNT;
+  }
+
+  // Returns true if this command should run when robot is disabled.
+  @Override
+  public boolean runsWhenDisabled() {
+      return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/DriveCSForwardDockCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCSForwardDockCommand.java
@@ -4,6 +4,7 @@
 
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.RobotConstants;
 import frc.robot.filters.DriveInput;
 import frc.robot.subsystems.DriveSubsystem;
@@ -19,6 +20,7 @@ public class DriveCSForwardDockCommand extends EntechCommandBase {
   private final NavXSubSystem navx;
   private double start_speed = 0.0;
   private double end_speed = 0.0;
+  private double startDistance;
 
   /**
    * Creates a new DriveCSForwardDockCommand.
@@ -55,13 +57,14 @@ public class DriveCSForwardDockCommand extends EntechCommandBase {
   @Override
   public void initialize() {
     drive.resetEncoders();
+    startDistance = drive.getAverageDistanceMeters();
+    startDistance = 0.0;
   }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-
-    double s = calculateSpeed(drive.getAverageDistanceMeters(), RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE, start_speed, end_speed);
+    double s = calculateSpeed(Math.abs(drive.getAverageDistanceMeters()-startDistance), RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE, start_speed, end_speed);
     DriveInput di=new DriveInput(s,0.0,0.0, navx.getYawAngleDegrees());
     drive.driveFilterYawRobotRelative(di);
   }
@@ -79,7 +82,11 @@ public class DriveCSForwardDockCommand extends EntechCommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-      return (drive.getAverageDistanceMeters() > RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE);
+    if (Math.abs(drive.getAverageDistanceMeters()-startDistance) > RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE) {
+        DriverStation.reportWarning("END:" + this, false);
+        return true;
+    }
+      return false;
   }
 
   // Returns true if this command should run when robot is disabled.

--- a/src/main/java/frc/robot/commands/DriveCSForwardDockCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCSForwardDockCommand.java
@@ -11,16 +11,16 @@ import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.NavXSubSystem;
 
 /**
- * Assumes that the robot has already tipped the charging station.  
+ * Assumes that the robot has already tipped the charging station.
  * Moves about 1 robot depth on to the charging station
  */
 public class DriveCSForwardDockCommand extends EntechCommandBase {
-  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-  private final DriveSubsystem drive;
-  private final NavXSubSystem navx;
-  private double start_speed = 0.0;
-  private double end_speed = 0.0;
-  private double startDistance;
+    @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+    private final DriveSubsystem drive;
+    private final NavXSubSystem navx;
+    private double start_speed = 0.0;
+    private double end_speed = 0.0;
+    private double startDistance;
 
   /**
    * Creates a new DriveCSForwardDockCommand.
@@ -29,7 +29,7 @@ public class DriveCSForwardDockCommand extends EntechCommandBase {
    * @param nsubsys NavX subsystem used for pitch measurement
    */
   public DriveCSForwardDockCommand(DriveSubsystem dsubsys, NavXSubSystem nsubsys) {
-	  super(dsubsys);
+      super(dsubsys);
       this.drive = dsubsys;
       this.navx = nsubsys;
       double pitch = this.navx.getPitch();
@@ -45,47 +45,50 @@ public class DriveCSForwardDockCommand extends EntechCommandBase {
    * @param speed Drive speed (forward is positive, default)
    */
   public DriveCSForwardDockCommand(DriveSubsystem dsubsys, NavXSubSystem nsubsys, double start_speed, double end_speed) {
-    super(dsubsys);
-    this.drive = dsubsys;
-    this.navx = nsubsys;
-    double pitch = this.navx.getPitch();
-    this.start_speed = Math.copySign(start_speed, pitch);
-    this.end_speed = Math.copySign(end_speed, pitch);
+      super(dsubsys);
+      this.drive = dsubsys;
+      this.navx = nsubsys;
+      double pitch = this.navx.getPitch();
+      this.start_speed = Math.copySign(start_speed, pitch);
+      this.end_speed = Math.copySign(end_speed, pitch);
   }
 
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    drive.resetEncoders();
-    startDistance = drive.getAverageDistanceMeters();
-    startDistance = 0.0;
+      // If for some reason, resetting the encoders does not work properly, the command can track the distance itself by
+      // removing the first two lines and replacing them with the last line
+      drive.resetEncoders();
+      startDistance = 0.0;
+      // startDistance = drive.getAverageDistanceMeters();
   }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    double s = calculateSpeed(Math.abs(drive.getAverageDistanceMeters()-startDistance), RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE, start_speed, end_speed);
-    DriveInput di=new DriveInput(s,0.0,0.0, navx.getYawAngleDegrees());
-    drive.driveFilterYawRobotRelative(di);
+      double s = calculateSpeed(Math.abs(drive.getAverageDistanceMeters()-startDistance), RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE, start_speed, end_speed);
+      DriveInput di=new DriveInput(s,0.0,0.0, navx.getYawAngleDegrees());
+      drive.driveFilterYawRobotRelative(di);
   }
 
   private double calculateSpeed(double distance, double dref, double speed0, double speed1) {
-    double fraction = Math.min(distance/dref, 1.0);
-    return (1.0-fraction)*speed0 + (fraction*speed1);
+      double fraction = Math.min(distance/dref, 1.0);
+      return (1.0-fraction)*speed0 + (fraction*speed1);
   }
 
   // Called once the command ends or is interrupted.
   @Override
-  public void end(boolean interrupted) { 
+  public void end(boolean interrupted) {
+      // do not stop the robot.  We assume the next command will take over a moving robot and try the balance
   }
 
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    if (Math.abs(drive.getAverageDistanceMeters()-startDistance) > RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE) {
-        DriverStation.reportWarning("END:" + this, false);
-        return true;
-    }
+      if (Math.abs(drive.getAverageDistanceMeters()-startDistance) > RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE) {
+          DriverStation.reportWarning("END:" + this, false);
+          return true;
+      }
       return false;
   }
 

--- a/src/main/java/frc/robot/commands/DriveCSForwardDockCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCSForwardDockCommand.java
@@ -1,0 +1,90 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import frc.robot.RobotConstants;
+import frc.robot.filters.DriveInput;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.NavXSubSystem;
+
+/**
+ * Assumes that the robot has already tipped the charging station.  
+ * Moves about 1 robot depth on to the charging station
+ */
+public class DriveCSForwardDockCommand extends EntechCommandBase {
+  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  private final DriveSubsystem drive;
+  private final NavXSubSystem navx;
+  private double start_speed = 0.0;
+  private double end_speed = 0.0;
+
+  /**
+   * Creates a new DriveCSForwardDockCommand.
+   *
+   * @param dsubsys Drive subsystem used by this command.
+   * @param nsubsys NavX subsystem used for pitch measurement
+   */
+  public DriveCSForwardDockCommand(DriveSubsystem dsubsys, NavXSubSystem nsubsys) {
+	  super(dsubsys);
+      this.drive = dsubsys;
+      this.navx = nsubsys;
+      double pitch = this.navx.getPitch();
+      start_speed = Math.copySign(RobotConstants.BALANCE_PARAMETERS.DOCK_INITIAL_SPEED, pitch);
+      end_speed = Math.copySign(RobotConstants.BALANCE_PARAMETERS.DOCK_FINAL_SPEED, pitch);
+  }
+
+  /**
+   * Creates a new DriveCSForwardDockCommand.
+   *
+   * @param dsubsys Drive subsystem used by this command.
+   * @param nsubsys NavX subsystem used for pitch measurement
+   * @param speed Drive speed (forward is positive, default)
+   */
+  public DriveCSForwardDockCommand(DriveSubsystem dsubsys, NavXSubSystem nsubsys, double start_speed, double end_speed) {
+    super(dsubsys);
+    this.drive = dsubsys;
+    this.navx = nsubsys;
+    double pitch = this.navx.getPitch();
+    this.start_speed = Math.copySign(start_speed, pitch);
+    this.end_speed = Math.copySign(end_speed, pitch);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    drive.resetEncoders();
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+
+    double s = calculateSpeed(drive.getAverageDistanceMeters(), RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE, start_speed, end_speed);
+    DriveInput di=new DriveInput(s,0.0,0.0, navx.getYawAngleDegrees());
+    drive.driveFilterYawRobotRelative(di);
+  }
+
+  private double calculateSpeed(double distance, double dref, double speed0, double speed1) {
+    double fraction = Math.min(distance/dref, 1.0);
+    return (1.0-fraction)*speed0 + (fraction*speed1);
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) { 
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+      return (drive.getAverageDistanceMeters() > RobotConstants.BALANCE_PARAMETERS.DOCK_DISTANCE);
+  }
+
+  // Returns true if this command should run when robot is disabled.
+  @Override
+  public boolean runsWhenDisabled() {
+      return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/DriveCSForwardTipCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCSForwardTipCommand.java
@@ -4,6 +4,7 @@
 
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.RobotConstants;
 import frc.robot.filters.DriveInput;
 import frc.robot.subsystems.DriveSubsystem;
@@ -72,12 +73,16 @@ public class DriveCSForwardTipCommand extends EntechCommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    double pitch = Math.abs(navx.getPitch());
-    if (pitch_seen && (pitch < last_pitch)) {
-        return true;
+    if (pitch_seen) {
+        DriverStation.reportWarning("END:" + this, false);
     }
-    last_pitch = pitch;
-    return false;
+    return pitch_seen;
+    // double pitch = Math.abs(navx.getPitch());
+    // if (pitch_seen && (pitch < last_pitch)) {
+    //     return true;
+    // }
+    // last_pitch = pitch;
+    // return false;
   }
 
   // Returns true if this command should run when robot is disabled.

--- a/src/main/java/frc/robot/commands/DriveCSForwardTipCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCSForwardTipCommand.java
@@ -1,0 +1,88 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import frc.robot.RobotConstants;
+import frc.robot.filters.DriveInput;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.NavXSubSystem;
+import frc.robot.subsystems.DriveSubsystem.DriveMode;
+
+public class DriveCSForwardTipCommand extends EntechCommandBase {
+  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  private final DriveSubsystem drive;
+  private final NavXSubSystem navx;
+  private double speed = 0.0;
+  private boolean pitch_seen;
+  private double last_pitch;
+
+  /**
+   * Creates a new DriveForwardToBalanceCommand.
+   *
+   * @param dsubsys Drive subsystem used by this command.
+   * @param nsubsys NavX subsystem used for pitch measurement
+   */
+  public DriveCSForwardTipCommand(DriveSubsystem dsubsys, NavXSubSystem nsubsys) {
+	  super(dsubsys,nsubsys);
+      this.drive = dsubsys;
+      this.navx = nsubsys;
+      this.speed = RobotConstants.BALANCE_PARAMETERS.CHARGESTATION_APPROACH_SPEED;
+  }
+
+  /**
+   * Creates a new DriveForwardToBalanceCommand.
+   *
+   * @param dsubsys Drive subsystem used by this command.
+   * @param nsubsys NavX subsystem used for pitch measurement
+   * @param speed Drive speed (forward is positive, default)
+   */
+  public DriveCSForwardTipCommand(DriveSubsystem dsubsys, NavXSubSystem nsubsys, double speed) {
+    super(dsubsys,nsubsys);
+    this.drive = dsubsys;
+    this.navx = nsubsys;
+    this.speed = speed;
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    last_pitch = Math.abs(navx.getPitch());
+    pitch_seen = false;
+    drive.setDriveMode(DriveMode.BRAKE);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+
+    if (Math.abs(navx.getPitch()) > RobotConstants.BALANCE_PARAMETERS.TIP_PITCH_THRESHOLD) {
+        pitch_seen = true;
+    }
+    DriveInput di=new DriveInput(speed,0.0,0.0, navx.getYawAngleDegrees());
+    drive.driveFilterYawRobotRelative(di);
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) { 
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    double pitch = Math.abs(navx.getPitch());
+    if (pitch_seen && (pitch < last_pitch)) {
+        return true;
+    }
+    last_pitch = pitch;
+    return false;
+  }
+
+  // Returns true if this command should run when robot is disabled.
+  @Override
+  public boolean runsWhenDisabled() {
+      return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/DriveForwardToBalanceCommand.java
+++ b/src/main/java/frc/robot/commands/DriveForwardToBalanceCommand.java
@@ -13,7 +13,7 @@ import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.NavXSubSystem;
 import frc.robot.subsystems.DriveSubsystem.DriveMode;
 
-public class DriveForwardToBalanceCommand extends EntechCommandBase {
+public class  DriveForwardToBalanceCommand extends EntechCommandBase {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
   private final DriveSubsystem drive;
   private final NavXSubSystem navx;
@@ -45,7 +45,7 @@ public class DriveForwardToBalanceCommand extends EntechCommandBase {
       drive = dsubsys;
       navx = nsubsys;
       brake = brakeSubsystem;
-      speed = RobotConstants.DRIVE.BALANCE_APPROACH_SPEED;
+      speed = RobotConstants.BALANCE_PARAMETERS.CHARGESTATION_APPROACH_SPEED;
       original_speed = speed;
       this.useBrakes = useBrakes;
       this.backNudgeTimer = new Timer();
@@ -67,98 +67,5 @@ public class DriveForwardToBalanceCommand extends EntechCommandBase {
     original_speed = speed;
     this.useBrakes = useBrakes;
     this.backNudgeTimer = new Timer();
-  }
-
-  // Called when the command is initially scheduled.
-  @Override
-  public void initialize() {
-    pitch_seen = false;
-    pitch_stable_count = 0;
-    speed = original_speed;
-    drive.setDriveMode(DriveMode.BRAKE);
-    backNudgeTimer.stop();
-    backNudgeTimer.reset();
-  }
-
-  // Called every time the scheduler runs while the command is scheduled.
-  @Override
-  public void execute() {
-
-    DriveInput di=new DriveInput(speed,0.0,0.0, navx.getYaw());
-    double pitch_angle = navx.getPitch();
-    if (!pitch_seen) {
-        if (Math.abs(pitch_angle) > PITCH_SLOW_THRESHOLD) {
-            pitch_seen = true;
-            this.speed = SPEED_AFTER_PITCH;
-            this.start_slowdown = drive.getAverageDistanceMeters();
-            this.speed = calculateSpeed(Math.abs(drive.getAverageDistanceMeters()-start_slowdown), 0.25*CHARGESTATION_DEPTH, original_speed, SPEED_AFTER_PITCH);
-        }
-        drive.driveFilterYawOnly(di);
-    } else {
-        if (Math.abs(pitch_angle) < PITCH_FLAT_THRESHOLD) {
-            if (pitch_stable_count == 0) {
-                backNudgeTimer.start();
-            }
-            if (backNudgeTimer.get() < BACK_NUDGE_TIME) {
-               di.setForward(Math.copySign(BACK_NUDGE_SPEED,-speed));
-               di.setRight(0.0);
-               di.setRotation(0.0);
-               drive.drive(di);
-            } else {
-               drive.stop();
-               if ( useBrakes ) {
-            	   brake.setBrakeState(BrakeState.kDeploy);
-               }
-            }
-            pitch_stable_count += 1;
-        } else {
-            if ( useBrakes ) {        	
-            	brake.setBrakeState(BrakeState.kRetract);
-            }
-            pitch_stable_count = 0;
-            backNudgeTimer.stop();
-            backNudgeTimer.reset();
-            this.speed = calculateSpeed(Math.abs(drive.getAverageDistanceMeters()-start_slowdown), 0.25*CHARGESTATION_DEPTH, original_speed, SPEED_AFTER_PITCH);
-            di.setForward(Math.copySign(this.speed, pitch_angle));
-            drive.drive(di);
-        }
-    }
-  }
-
-  private double calculateSpeed(double distance, double dref, double speed0, double speed1) {
-    double fraction = Math.min(distance/dref, 1.0);
-    return (1.0-fraction)*speed0 + (fraction*speed1);
-  }
-
-  // Called once the command ends or is interrupted.
-  @Override
-  public void end(boolean interrupted) { 
-	/** NOTE:
-	 * this command is used in two contexts: in auto, and activated by driver in 
-	 * endgame.
-	 * In auto, the balance time (ROBOT_STABLE_COUNT) is long enough that the 
-	 * command will not end before autonomous ends. it will continually try to seek balance and stop
-	 * 
-	 * In endgame, we want the operator to have control, but to use the balancing code to mount.
-	 * the operator runs this command, and then when happy holds down the brake button.
-	 * The brake button will cancel this command.  We free the the brakes so that the operator
-	 * can move if they choose to do so
-	**/
-      if ( useBrakes ) {
-      	brake.setBrakeState(BrakeState.kRetract);
-      }
-  	drive.stop();	  
-  }
-
-  // Returns true when the command should end.
-  @Override
-  public boolean isFinished() {
-      return pitch_stable_count > ROBOT_STABLE_COUNT;
-  }
-
-  // Returns true if this command should run when robot is disabled.
-  @Override
-  public boolean runsWhenDisabled() {
-      return false;
   }
 }

--- a/src/main/java/frc/robot/oi/OperatorInterface.java
+++ b/src/main/java/frc/robot/oi/OperatorInterface.java
@@ -33,7 +33,7 @@ public class OperatorInterface {
             .onTrue(commandFactory.getYawToNearestPerpendicular());
 
         driveStick.button(RobotConstants.DRIVER_STICK.AUTO_BALANCE_FORWARD)
-            .whileTrue(commandFactory.autoDriveBalanceOnly(RobotConstants.DRIVE.BALANCE_APPROACH_SPEED,false));
+            .whileTrue(commandFactory.autoDriveBalanceOnly(RobotConstants.BALANCE_PARAMETERS.CHARGESTATION_APPROACH_SPEED,false));
 
         driveStick.button(RobotConstants.DRIVER_STICK.DEPLOY_BRAKE)
             .onTrue(commandFactory.deployBrakeCommand())

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -151,6 +151,15 @@ public class DriveSubsystem extends EntechSubsystem {
         DriveInput filtered = yawHoldFilter.filter(di);
         drive(filtered);
     }
+  
+    public void driveFilterYawRobotRelative(DriveInput di) {
+
+        if ( ! yawHoldFilter.isSetpointValid() ) {
+            yawHoldFilter.setSetpoint(di.getYawAngleDegrees());
+        }
+        DriveInput filtered = robotRelativeFilter.filter(yawHoldFilter.filter(di));
+        drive(filtered);
+    }
     public void filteredDrive(DriveInput di) {
 
         // Special case: set the setpoint for the HoldYawFilter if nothing has until now


### PR DESCRIPTION
The PR changes the balancing command into 3 separate commands for the following stages:
1. robot climbs the ramp and tilts the charge station down
2. robot moves a distance onto the charging station (ignoring the angle)
3. robot tries to balance using simple flip-flop controller
The change should only be in effect for over and back autonomous.